### PR TITLE
Version 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then set crontab:
 [Pro tips] When you want to avoid thundering herd:
 
 ```crontab
-*/3 * * * * bash -c 'sleep $(($RANDOM \% 60)) && /usr/local/bin/moknfish -w'
+*/3 * * * * /usr/local/bin/moknfish -random-delay 60'
 ```
 
 After this the `/etc/hosts` will be periodicaly updated from `/etc/hosts.base` and existing server networks.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Usage of monkfish:
   -V    Verbose mode
   -c string
         Config path (default "/etc/monkfish.ini")
+  -random-delay int
+        Random delay before to access OpenStack API, in second
   -t string
         Target file to write hosts (default "/etc/hosts")
   -version
@@ -48,6 +50,7 @@ os_region = "RegionOne"
 domain = "monk.example.tld"
 internal_domain = "monk.local"
 lan_ip_prefix = "10.10.100." # Optional
+use_only_hostname = true     # Optional, when you want instances named like `foo001.example.tld` to be `foo001.your.lan`
 ```
 
 Then set crontab:

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package monkfish
 
-const Version = "0.1.0"
+const Version = "0.2.0"


### PR DESCRIPTION
Add features:
- `use_only_hostname` setting: Useful when you want instances named like `foo001.example.tld` to be `foo001.your.lan`
- `-random-delay` option to avoid thundering herd
